### PR TITLE
CIVIMM-485: Add Option To Hide Versafix Compuco Base Template

### DIFF
--- a/custommosaico.php
+++ b/custommosaico.php
@@ -37,12 +37,20 @@ function custommosaico_civicrm_enable() {
  * Implements hook_civicrm_mosaicoBaseTemplates().
  */
 function custommosaico_civicrm_mosaicoBaseTemplates(&$templates) {
+  // Existing mailings that already uses this template
+  $existingMailing = Civi\Api4\Mailing::get(FALSE)
+    ->addWhere('template_options', 'LIKE', '%versafix-compuco%')
+    ->setLimit(1)
+    ->execute();
+
   // Add custom mail template for mosaico.
   $templates['custommosaico'] = [
     'name' => 'versafix-compuco',
     'title' => 'Versafix Compuco',
     'path' => E::url('packages/compuco/templates/versafix-compuco/template-versafix-compuco.html'),
     'thumbnail' => E::url('packages/compuco/templates/versafix-compuco/edres/_full.png'),
+    'is_hidden' => (\Civi::settings()->get('custommosaico_hide_versafix_compuco_base_template') !== FALSE)
+    && $existingMailing->count() === 0,
   ];
 }
 

--- a/settings/Custommosaico.setting.php
+++ b/settings/Custommosaico.setting.php
@@ -48,4 +48,17 @@ return [
     'description' => ts('If enabled, Mosaico editor will display the selected brand colours in the colour picker.'),
     'settings_pages' => ['mosaico' => ['weight' => 152]],
   ],
+  'custommosaico_hide_versafix_compuco_base_template' => [
+    'name' => 'custommosaico_hide_versafix_compuco_base_template',
+    'type' => 'Boolean',
+    'default' => TRUE,
+    'html_type' => 'checkbox',
+    'is_domain' => 1,
+    'title' => E::ts('Hide Versafix Compuco base template.'),
+    'description' => ts('If enabled, Mosaico editor will not display Versafix Compuco base template.'),
+    'settings_pages' => ['mosaico' => ['weight' => 153]],
+    'html_attributes' => [
+      'checked' => TRUE,
+    ],
+  ],
 ];


### PR DESCRIPTION
## Overview
This PR adds a new setting to mosaico settings page which can be utilized to hide the outdated versafix compuco base template from mosaico editor. The setting is enabled by default which means as soon as this code is deployed to any site this setting can have its effect immediately.

## Before
There was no way to hide versafix compuco base template.

## After
<img width="1792" height="1120" alt="Screenshot 2026-03-05 at 6 08 12 PM" src="https://github.com/user-attachments/assets/40e700eb-5f4a-415d-a91a-d10f8b50767b" />
The above setting can be used to hide the outdated template.

## Technical Details
The above setting only has en impact if none of the mailings are already using this template, but if any mailing is using this template then the above setting will have no effect and the template will continue to be visible.
